### PR TITLE
Disable 'trust-clang-manging' in bindgen call; fixes linker issues.

### DIFF
--- a/aio-bindings/build.rs
+++ b/aio-bindings/build.rs
@@ -12,7 +12,8 @@ fn main() {
     // to bindgen, and lets you build up options for
     // the resulting bindings.
     let bindings = bindgen::Builder::default()
-        // The input header we would like to generate
+        .trust_clang_mangling(false)
+         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
         // Finish the builder and generate the bindings.


### PR DESCRIPTION
Without this change, 'cargo test' (or building anything using the library) fails at link stage with:

/home/kvigor/tokio-linux-aio/src/aio.rs:49: undefined reference to `syscall'

I am no bindgen expert, so I don't know if this is best possible fix, but it works for me.