### PR TITLE
Support futures cancellation. Migrate to parking_lot

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,7 @@ mio = "0.6.13"
 aio-bindings = { path = "aio-bindings", version = "0.1.2" }
 libc = "0.2"
 memmap = "0.7.0"
+parking_lot = "0.7.1"
+fnv = "1.0.6"
 
 [workspace]


### PR DESCRIPTION
The current implementation doesn't support future cancellation. If the future that scheduled AIO action was canceled, the data (which was previously sent in `aio_data`) will be freed, but `AioPollFuture` will try to unsafely reuse the freed pointer. This PR fixes the problem but unfortunately introduces some performance penalty. 